### PR TITLE
Rolling back base image to Nodejs18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-20@sha256:65d6f975014181e347f78fa510637778e93f57a2b65e9aad62970c142de5899e as Build
+FROM registry.access.redhat.com/ubi9/nodejs-18@sha256:d9afd90b5f290f3db255dfeff667837fe643ec3e650e85ac7aae45b79e694d42 as Build
 
 COPY . .
 USER root


### PR DESCRIPTION
Should fix a perms issue I was running into getting this to run on cluster.