### PR TITLE
feat(ux): add dynamic labels & helper text for settings + search form

### DIFF
--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -37,6 +37,7 @@ type Rules = Omit<
 interface InputConfig {
 	name: string;
 	helperText?: ReactNode;
+	placeholder?: string;
 	rules: Rules;
 	tooltipText?: ReactNode;
 }
@@ -44,6 +45,7 @@ interface InputConfig {
 const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	email: {
 		name: "Email",
+		placeholder: "jdoe@example.com",
 		rules: {
 			pattern: {
 				value: /\S+@\S+\.\S+/,
@@ -54,6 +56,8 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	},
 	hash: {
 		name: "Hash",
+		placeholder:
+			"sha256:8ceb4ab8127731473a9ec81140cb6849cf8e970cda31baef099df48ba3264441",
 		rules: {
 			pattern: {
 				value: /^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$/,
@@ -81,6 +85,7 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 				entries
 			</>
 		),
+		placeholder: "6d78e27dfcf83eaad6ef73c4695d1ddc663f5555",
 		rules: {
 			pattern: {
 				value: /^[0-9a-fA-F]{40}$/,
@@ -93,6 +98,8 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	uuid: {
 		name: "Entry UUID",
 		helperText: <>Search by the universally unique identifier value.</>,
+		placeholder:
+			"24296fb24b8ad77a71b9c1374e207537bafdd75b4f591dcee10f3f697f150d7cc5d0b725eea641e7",
 		rules: {
 			pattern: {
 				value: /^[0-9a-fA-F]{64}|[0-9a-fA-F]{80}$/,
@@ -105,6 +112,7 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	logIndex: {
 		name: "Log Index",
 		helperText: <>Search by the log index number.</>,
+		placeholder: "1234567",
 		rules: {
 			min: {
 				value: 0,
@@ -232,7 +240,9 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 											watchAttribute
 										].name.toLowerCase()}`}
 										label={inputConfigByAttribute[watchAttribute].name}
-										placeholder={inputConfigByAttribute[watchAttribute].name}
+										placeholder={
+											inputConfigByAttribute[watchAttribute].placeholder
+										}
 										type={
 											inputConfigByAttribute[watchAttribute].name === "email"
 												? "email"
@@ -261,10 +271,10 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				</Flex>
 				<Flex
 					direction={{ default: "column" }}
-					alignSelf={{ default: "alignSelfFlexEnd" }}
+					alignSelf={{ default: "alignSelfFlexStart" }}
 					flex={{ default: "flex_1" }}
 				>
-					<FlexItem>
+					<FlexItem style={{ marginTop: "2em" }}>
 						<Button
 							variant="primary"
 							id="search-form-button"

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -38,6 +38,7 @@ interface InputConfig {
 	name: string;
 	helperText?: ReactNode;
 	rules: Rules;
+	tooltipText?: ReactNode;
 }
 
 const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
@@ -49,6 +50,7 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 				message: "Entered value does not match the email format: 'S+@S+.S+'",
 			},
 		},
+		tooltipText: <>Search by the signer&apos;s email address.</>,
 	},
 	hash: {
 		name: "Hash",
@@ -59,6 +61,7 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 					"Entered value does not match the hash format: '^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$'",
 			},
 		},
+		tooltipText: <>Search by the SHA1 or SHA2 hash value.</>,
 	},
 	commitSha: {
 		name: "Commit SHA",
@@ -85,9 +88,11 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 					"Entered value does not match the commit SHA format: '^[0-9a-fA-F]{40}$'",
 			},
 		},
+		tooltipText: <>Search by the commit hash.</>,
 	},
 	uuid: {
 		name: "Entry UUID",
+		helperText: <>Search by the universally unique identifier value.</>,
 		rules: {
 			pattern: {
 				value: /^[0-9a-fA-F]{64}|[0-9a-fA-F]{80}$/,
@@ -95,9 +100,11 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 					"Entered value does not match the entry UUID format: '^[0-9a-fA-F]{64}|[0-9a-fA-F]{80}$'",
 			},
 		},
+		tooltipText: <>Search by the universally unique identifier value.</>,
 	},
 	logIndex: {
 		name: "Log Index",
+		helperText: <>Search by the log index number.</>,
 		rules: {
 			min: {
 				value: 0,
@@ -108,6 +115,7 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 				message: "Entered value must be of type int64",
 			},
 		},
+		tooltipText: <>Search by the log index number.</>,
 	},
 };
 
@@ -121,47 +129,6 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				value: "",
 			},
 		});
-	const [attrHelperHeader, setAttrHelperHeader] = useState(
-		<div>
-			The{" "}
-			<a
-				href="https://schema.org/name"
-				target="_blank"
-				rel="noreferrer"
-			>
-				name
-			</a>{" "}
-			of a{" "}
-			<a
-				href="https://schema.org/Person"
-				target="_blank"
-				rel="noreferrer"
-			>
-				Person
-			</a>
-		</div>,
-	);
-	const [attrHelperBody, setAttrHelperBody] = useState(
-		<div>
-			Often composed of{" "}
-			<a
-				href="https://schema.org/givenName"
-				target="_blank"
-				rel="noreferrer"
-			>
-				givenName
-			</a>{" "}
-			and{" "}
-			<a
-				href="https://schema.org/familyName"
-				target="_blank"
-				rel="noreferrer"
-			>
-				familyName
-			</a>
-			.
-		</div>,
-	);
 
 	useEffect(() => {
 		if (defaultValues) {
@@ -195,7 +162,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 			<Flex>
 				<Flex
 					direction={{ default: "column" }}
-					grow={{ default: "grow" }}
+					flex={{ default: "flex_3" }}
 				>
 					<FlexItem>
 						<Controller
@@ -207,14 +174,16 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 									fieldId={"rekor-search-attribute"}
 									labelIcon={
 										<Popover
-											headerContent={attrHelperHeader}
-											bodyContent={attrHelperBody}
+											bodyContent={
+												inputConfigByAttribute[watchAttribute].tooltipText
+											}
+											position={"right"}
 										>
 											<button
 												type="button"
 												aria-label="More info for attribute field"
 												onClick={e => e.preventDefault()}
-												aria-describedby="form-group-label-info"
+												aria-describedby="attribute-info"
 												className={styles.formGroupLabelHelp}
 											>
 												<HelpIcon />
@@ -242,7 +211,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				</Flex>
 				<Flex
 					direction={{ default: "column" }}
-					grow={{ default: "grow" }}
+					flex={{ default: "flex_3" }}
 				>
 					<FlexItem>
 						<Controller
@@ -251,16 +220,24 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 							rules={rules}
 							render={({ field, fieldState }) => (
 								<FormGroup
-									label={"Email"}
-									fieldId={"rekor-search-email"}
+									label={inputConfigByAttribute[watchAttribute].name}
+									fieldId={`rekor-search-${inputConfigByAttribute[
+										watchAttribute
+									].name.toLowerCase()}`}
 								>
 									<TextInput
 										aria-label={`${inputConfigByAttribute[watchAttribute].name} input field`}
 										{...field}
-										id={"rekor-search-email"}
+										id={`rekor-search-${inputConfigByAttribute[
+											watchAttribute
+										].name.toLowerCase()}`}
 										label={inputConfigByAttribute[watchAttribute].name}
 										placeholder={inputConfigByAttribute[watchAttribute].name}
-										type={"email"}
+										type={
+											inputConfigByAttribute[watchAttribute].name === "email"
+												? "email"
+												: "text"
+										}
 										validated={fieldState.invalid ? "error" : "default"}
 									/>
 									{fieldState.invalid && (
@@ -285,6 +262,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				<Flex
 					direction={{ default: "column" }}
 					alignSelf={{ default: "alignSelfFlexEnd" }}
+					flex={{ default: "flex_1" }}
 				>
 					<FlexItem>
 						<Button

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -12,7 +12,7 @@ import {
 	Popover,
 	TextInput,
 } from "@patternfly/react-core";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Controller, RegisterOptions, useForm } from "react-hook-form";
 import { Attribute, ATTRIBUTES } from "../api/rekor_api";
 import { ExclamationCircleIcon, HelpIcon } from "@patternfly/react-icons";
@@ -121,6 +121,47 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				value: "",
 			},
 		});
+	const [attrHelperHeader, setAttrHelperHeader] = useState(
+		<div>
+			The{" "}
+			<a
+				href="https://schema.org/name"
+				target="_blank"
+				rel="noreferrer"
+			>
+				name
+			</a>{" "}
+			of a{" "}
+			<a
+				href="https://schema.org/Person"
+				target="_blank"
+				rel="noreferrer"
+			>
+				Person
+			</a>
+		</div>,
+	);
+	const [attrHelperBody, setAttrHelperBody] = useState(
+		<div>
+			Often composed of{" "}
+			<a
+				href="https://schema.org/givenName"
+				target="_blank"
+				rel="noreferrer"
+			>
+				givenName
+			</a>{" "}
+			and{" "}
+			<a
+				href="https://schema.org/familyName"
+				target="_blank"
+				rel="noreferrer"
+			>
+				familyName
+			</a>
+			.
+		</div>,
+	);
 
 	useEffect(() => {
 		if (defaultValues) {
@@ -166,51 +207,12 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 									fieldId={"rekor-search-attribute"}
 									labelIcon={
 										<Popover
-											headerContent={
-												<div>
-													The{" "}
-													<a
-														href="https://schema.org/name"
-														target="_blank"
-														rel="noreferrer"
-													>
-														name
-													</a>{" "}
-													of a{" "}
-													<a
-														href="https://schema.org/Person"
-														target="_blank"
-														rel="noreferrer"
-													>
-														Person
-													</a>
-												</div>
-											}
-											bodyContent={
-												<div>
-													Often composed of{" "}
-													<a
-														href="https://schema.org/givenName"
-														target="_blank"
-														rel="noreferrer"
-													>
-														givenName
-													</a>{" "}
-													and{" "}
-													<a
-														href="https://schema.org/familyName"
-														target="_blank"
-														rel="noreferrer"
-													>
-														familyName
-													</a>
-													.
-												</div>
-											}
+											headerContent={attrHelperHeader}
+											bodyContent={attrHelperBody}
 										>
 											<button
 												type="button"
-												aria-label="More info for name field"
+												aria-label="More info for attribute field"
 												onClick={e => e.preventDefault()}
 												aria-describedby="form-group-label-info"
 												className={styles.formGroupLabelHelp}
@@ -283,7 +285,6 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 				<Flex
 					direction={{ default: "column" }}
 					alignSelf={{ default: "alignSelfFlexEnd" }}
-					grow={{ default: "grow" }}
 				>
 					<FlexItem>
 						<Button

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -7,16 +7,16 @@ import {
 	FormHelperText,
 	FormSelect,
 	FormSelectOption,
-	Grid,
-	GridItem,
 	HelperText,
 	HelperTextItem,
+	Popover,
 	TextInput,
 } from "@patternfly/react-core";
 import { ReactNode, useEffect } from "react";
 import { Controller, RegisterOptions, useForm } from "react-hook-form";
 import { Attribute, ATTRIBUTES } from "../api/rekor_api";
-import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { ExclamationCircleIcon, HelpIcon } from "@patternfly/react-icons";
+import styles from "@patternfly/react-styles/css/components/Form/form";
 
 export interface FormProps {
 	defaultValues?: FormInputs;
@@ -164,6 +164,61 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 								<FormGroup
 									label={"Attribute"}
 									fieldId={"rekor-search-attribute"}
+									labelIcon={
+										<Popover
+											headerContent={
+												<div>
+													The{" "}
+													<a
+														href="https://schema.org/name"
+														target="_blank"
+														rel="noreferrer"
+													>
+														name
+													</a>{" "}
+													of a{" "}
+													<a
+														href="https://schema.org/Person"
+														target="_blank"
+														rel="noreferrer"
+													>
+														Person
+													</a>
+												</div>
+											}
+											bodyContent={
+												<div>
+													Often composed of{" "}
+													<a
+														href="https://schema.org/givenName"
+														target="_blank"
+														rel="noreferrer"
+													>
+														givenName
+													</a>{" "}
+													and{" "}
+													<a
+														href="https://schema.org/familyName"
+														target="_blank"
+														rel="noreferrer"
+													>
+														familyName
+													</a>
+													.
+												</div>
+											}
+										>
+											<button
+												type="button"
+												aria-label="More info for name field"
+												onClick={e => e.preventDefault()}
+												aria-describedby="form-group-label-info"
+												className={styles.formGroupLabelHelp}
+											>
+												<HelpIcon />
+											</button>
+										</Popover>
+									}
 								>
 									<FormSelect
 										id="rekor-search-attribute"
@@ -231,22 +286,17 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 					grow={{ default: "grow" }}
 				>
 					<FlexItem>
-						<FormGroup
-							label={" "}
-							fieldId={"search-form-button"}
+						<Button
+							variant="primary"
+							id="search-form-button"
+							isBlock={true}
+							isLoading={isLoading}
+							type="submit"
+							spinnerAriaLabel={"Loading"}
+							spinnerAriaLabelledBy={"search-form-button"}
 						>
-							<Button
-								variant="primary"
-								id="search-form-button"
-								isBlock={true}
-								isLoading={isLoading}
-								type="submit"
-								spinnerAriaLabel={"Loading"}
-								spinnerAriaLabelledBy={"search-form-button"}
-							>
-								Search
-							</Button>
-						</FormGroup>
+							Search
+						</Button>
 					</FlexItem>
 				</Flex>
 			</Flex>

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -73,14 +73,14 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 			<>
 				Only compatible with{" "}
 				<a
-					href="https://github.com/sigstore/gitsign"
+					href="https://access.redhat.com/documentation/en-us/red_hat_trusted_artifact_signer/2024-q1/html/deployment_guide/verify_the_trusted_artifact_signer_installation#signing-and-verifying-commits-by-using-gitsign-from-the-command-line-interface_deploy"
 					target="_blank"
 					rel="noopener noreferrer"
 					style={{
 						textDecoration: "underline",
 					}}
 				>
-					sigstore/gitsign
+					gitsign
 				</a>{" "}
 				entries
 			</>

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -1,6 +1,9 @@
 import {
 	Button,
+	Flex,
+	FlexItem,
 	Form,
+	FormGroup,
 	FormHelperText,
 	FormSelect,
 	FormSelectOption,
@@ -148,81 +151,105 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 
 	return (
 		<Form onSubmit={handleSubmit(onSubmit)}>
-			<Grid hasGutter={true}>
-				<GridItem sm={4}>
-					<Controller
-						name="attribute"
-						control={control}
-						render={({ field }) => (
-							<FormSelect
-								id="rekor-search-type"
-								{...field}
-								label="Attribute"
-							>
-								{ATTRIBUTES.map(attribute => (
-									<FormSelectOption
-										label={inputConfigByAttribute[attribute].name}
-										key={attribute}
-										value={attribute}
+			<Flex>
+				<Flex
+					direction={{ default: "column" }}
+					grow={{ default: "grow" }}
+				>
+					<FlexItem>
+						<Controller
+							name="attribute"
+							control={control}
+							render={({ field }) => (
+								<FormGroup
+									label={"Attribute"}
+									fieldId={"rekor-search-attribute"}
+								>
+									<FormSelect
+										id="rekor-search-attribute"
+										{...field}
+										label="Attribute"
+									>
+										{ATTRIBUTES.map(attribute => (
+											<FormSelectOption
+												label={inputConfigByAttribute[attribute].name}
+												key={attribute}
+												value={attribute}
+											/>
+										))}
+									</FormSelect>
+								</FormGroup>
+							)}
+						/>
+					</FlexItem>
+				</Flex>
+				<Flex
+					direction={{ default: "column" }}
+					grow={{ default: "grow" }}
+				>
+					<FlexItem>
+						<Controller
+							name="value"
+							control={control}
+							rules={rules}
+							render={({ field, fieldState }) => (
+								<FormGroup
+									label={"Email"}
+									fieldId={"rekor-search-email"}
+								>
+									<TextInput
+										aria-label={`${inputConfigByAttribute[watchAttribute].name} input field`}
+										{...field}
+										id={"rekor-search-email"}
+										label={inputConfigByAttribute[watchAttribute].name}
+										placeholder={inputConfigByAttribute[watchAttribute].name}
+										type={"email"}
+										validated={fieldState.invalid ? "error" : "default"}
 									/>
-								))}
-							</FormSelect>
-						)}
-					/>
-				</GridItem>
-				<GridItem
-					sm={8}
-					md={6}
+									{fieldState.invalid && (
+										<FormHelperText>
+											<HelperText>
+												<HelperTextItem
+													icon={<ExclamationCircleIcon />}
+													variant={fieldState.invalid ? "error" : "success"}
+												>
+													{fieldState.invalid
+														? fieldState.error?.message
+														: inputConfigByAttribute[watchAttribute].helperText}
+												</HelperTextItem>
+											</HelperText>
+										</FormHelperText>
+									)}
+								</FormGroup>
+							)}
+						/>
+					</FlexItem>
+				</Flex>
+				<Flex
+					direction={{ default: "column" }}
+					alignSelf={{ default: "alignSelfFlexEnd" }}
+					grow={{ default: "grow" }}
 				>
-					<Controller
-						name="value"
-						control={control}
-						rules={rules}
-						render={({ field, fieldState }) => (
-							<>
-								<TextInput
-									aria-label={`${inputConfigByAttribute[watchAttribute].name} input field`}
-									{...field}
-									label={inputConfigByAttribute[watchAttribute].name}
-									placeholder={inputConfigByAttribute[watchAttribute].name}
-									type={"email"}
-									validated={fieldState.invalid ? "error" : "default"}
-								/>
-								{fieldState.invalid && (
-									<FormHelperText>
-										<HelperText>
-											<HelperTextItem
-												icon={<ExclamationCircleIcon />}
-												variant={fieldState.invalid ? "error" : "success"}
-											>
-												{fieldState.invalid
-													? fieldState.error?.message
-													: inputConfigByAttribute[watchAttribute].helperText}
-											</HelperTextItem>
-										</HelperText>
-									</FormHelperText>
-								)}
-							</>
-						)}
-					/>
-				</GridItem>
-				<GridItem
-					sm={12}
-					md={2}
-				>
-					<Button
-						variant="primary"
-						id="search-form-button"
-						isBlock={true}
-						isLoading={isLoading}
-						type="submit"
-						spinnerAriaLabel={"Loading"}
-						spinnerAriaLabelledBy={"search-form-button"}
-					>
-						Search
-					</Button>
-				</GridItem>
-			</Grid>
+					<FlexItem>
+						<FormGroup
+							label={" "}
+							fieldId={"search-form-button"}
+						>
+							<Button
+								variant="primary"
+								id="search-form-button"
+								isBlock={true}
+								isLoading={isLoading}
+								type="submit"
+								spinnerAriaLabel={"Loading"}
+								spinnerAriaLabelledBy={"search-form-button"}
+							>
+								Search
+							</Button>
+						</FormGroup>
+					</FlexItem>
+				</Flex>
+			</Flex>
 		</Form>
 	);
 }

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -97,7 +97,6 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	},
 	uuid: {
 		name: "Entry UUID",
-		helperText: <>Search by the universally unique identifier value.</>,
 		placeholder:
 			"24296fb24b8ad77a71b9c1374e207537bafdd75b4f591dcee10f3f697f150d7cc5d0b725eea641e7",
 		rules: {
@@ -111,7 +110,6 @@ const inputConfigByAttribute: Record<FormInputs["attribute"], InputConfig> = {
 	},
 	logIndex: {
 		name: "Log Index",
-		helperText: <>Search by the log index number.</>,
 		placeholder: "1234567",
 		rules: {
 			min: {
@@ -229,6 +227,7 @@ export function SearchForm({ defaultValues, onSubmit, isLoading }: FormProps) {
 							render={({ field, fieldState }) => (
 								<FormGroup
 									label={inputConfigByAttribute[watchAttribute].name}
+									labelInfo={inputConfigByAttribute[watchAttribute].helperText}
 									fieldId={`rekor-search-${inputConfigByAttribute[
 										watchAttribute
 									].name.toLowerCase()}`}

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -7,7 +7,10 @@ import {
 	TextInput,
 	Form,
 	FormGroup,
+	Popover,
 } from "@patternfly/react-core";
+import { HelpIcon } from "@patternfly/react-icons";
+import styles from "@patternfly/react-styles/css/components/Form/form";
 
 export function Settings({
 	open,
@@ -65,6 +68,19 @@ export function Settings({
 			<Form id="settings-form">
 				<FormGroup
 					label="Override Rekor Endpoint"
+					labelIcon={
+						<Popover bodyContent={"Specify your private Rekor endpoint URL."}>
+							<button
+								type="button"
+								aria-label="More info for name field"
+								onClick={e => e.preventDefault()}
+								aria-describedby="form-group-label-info"
+								className={styles.formGroupLabelHelp}
+							>
+								<HelpIcon />
+							</button>
+						</Popover>
+					}
 					isRequired
 					fieldId="rekor-endpoint-override"
 				>
@@ -73,7 +89,9 @@ export function Settings({
 						type="text"
 						onChange={handleChangeBaseUrl}
 						placeholder={
-							baseUrl === undefined ? "https://rekor.sigstore.dev" : baseUrl
+							baseUrl === undefined
+								? "https://private.rekor.example.com"
+								: baseUrl
 						}
 						aria-label="override rekor endpoint"
 					/>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,7 @@ import { CogIcon, GithubIcon } from "@patternfly/react-icons";
 import Link from "next/link";
 import Image from "next/image";
 import NOSSRWrapper from "../modules/utils/noSSR";
+import logo from "/public/Logo-Red_Hat-Trusted_Artifact_Signer-A-Reverse-RGB.svg";
 
 const Home: NextPage = () => {
 	const [settingsOpen, setSettingsOpen] = useState(false);
@@ -33,10 +34,10 @@ const Home: NextPage = () => {
 					<MastheadMain>
 						<Link
 							href={"/"}
-							className={"pf-v5-c-masthead_brand"}
+							as={"image"}
 						>
 							<Image
-								src={"/Logo-Red_Hat-Trusted_Artifact_Signer-A-Reverse-RGB.svg"}
+								src={logo}
 								alt={"Red Hat Trusted Artifact Signer logo"}
 								priority={true}
 								width={127}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,10 +32,7 @@ const Home: NextPage = () => {
 			header={
 				<Masthead>
 					<MastheadMain>
-						<Link
-							href={"/"}
-							as={"image"}
-						>
+						<Link href={"/"}>
 							<Image
 								src={logo}
 								alt={"Red Hat Trusted Artifact Signer logo"}


### PR DESCRIPTION
This PR improves the user experience relating to the Search Form and Settings components.

Marked as draft until getting testing framework PR merged in.

Relates to [SECURESIGN-651](https://issues.redhat.com/browse/SECURESIGN-651)

## Changes

- Adds labels for search form fields
- Adds popover with helper text for each attribute in the search form
- Adds popover with helper text for overriding Rekor endpoint in Settings
- Adds support to show additional label text for the Commit SHA attribute
- Adds dynamic placeholders with more realistic examples
- Updates link to gitsign repo to point to TAS deployment docs

## Screenshots

![Screen capture](https://github.com/securesign/rekor-search-ui/assets/3844502/0b9a07e2-2211-4c92-89be-60e9b68ae740)

![screenshot-localhost_3000-2024 03 08-14_05_57](https://github.com/securesign/rekor-search-ui/assets/3844502/3e71e07d-bff1-4186-aafa-1ec01a313a03)

![screenshot-localhost_3000-2024 03 08-14_06_04](https://github.com/securesign/rekor-search-ui/assets/3844502/62e41fcc-86eb-41bc-8d94-49d289c7bdef)

![screenshot-localhost_3000-2024 03 08-14_29_25](https://github.com/securesign/rekor-search-ui/assets/3844502/ff41ff59-f00e-4062-99c5-bbc35cd0ffce)

