### PR TITLE
chore(toolbar): remove github link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -70,18 +70,6 @@ const Home: NextPage = () => {
 												ouiaId={"setting-button"}
 											/>
 										</ToolbarItem>
-										<ToolbarItem>
-											<Button
-												component="a"
-												href="https://github.com/sigstore/rekor-search-ui"
-												icon={<GithubIcon />}
-												target="_blank"
-												variant={"plain"}
-												ouiaId={"github-link"}
-												aria-label={"GitHub Link"}
-												rel="noopener noreferrer"
-											/>
-										</ToolbarItem>
 									</ToolbarGroup>
 								</ToolbarGroup>
 							</ToolbarContent>


### PR DESCRIPTION
Removes the link to GitHub in the toolbar.

## Screenshot

![screenshot-localhost_3000-2024 03 08-14_58_08](https://github.com/securesign/rekor-search-ui/assets/3844502/e8f8a979-6022-484b-8680-c76e4c018a7e)
