### PR TITLE
ci(pages): update node to v20 in nextjs.yml workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
To fix warning about building GitHub pages: https://github.com/securesign/rekor-search-ui/actions/runs/8205938602