### PR TITLE
build(ci): disable static pages from building

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,8 +6,8 @@ name: Deploy Next.js site to Pages
 
 on:
   # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+#  push:
+#    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Now that we are no longer fully client-side since adding support for runtime variables (#37), we should disable static site generation. This PR makes the `nextjs.yml` workflow a manually-triggered workflow.