### PR TITLE
fix(build): default to upstream API if no env var is set

### DIFF
--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -85,7 +85,7 @@ export function Settings({
 					fieldId="rekor-endpoint-override"
 				>
 					<TextInput
-						value={localBaseUrl ?? ""}
+						value={localBaseUrl ?? "https://rekor.sigstore.dev"}
 						type="text"
 						onChange={handleChangeBaseUrl}
 						placeholder={

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -116,8 +116,10 @@ export default PageComponent;
 export async function getServerSideProps() {
 	return {
 		props: {
-			NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN:
-				process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN,
-		}, // will be passed to the page component as props
+			NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: process.env
+				.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+				? process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+				: null,
+		}, // gets passed to the page component as props
 	};
 }


### PR DESCRIPTION
This PR fixes a breaking build where if you do not specify `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` as an environment variable it returns `undefined` which is not serializable by JSON. In addition, the Rekor Search UI will be unusable unless a Rekor server `baseUrl` is provided.

Changes:
- returns `null` instead of `undefined` for `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` as a server-side prop, to make the environment variable serializable (and prevent the build from failing)
- reimplements the same approach as upstream, defaulting to the upstream API again if nothing has been set, so that the UI has some functionality in the meantime

