### PR TITLE
build(ci): disable next export, use build time vars for static build

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,8 +75,10 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
-      - name: Static HTML export with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next export
+        env:
+          NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: ${{ secrets.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN }}
+      #      - name: Static HTML export with Next.js
+      #        run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,10 @@ const { codecovWebpackPlugin } = require("@codecov/webpack-plugin");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	env: {
+		NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN:
+			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN,
+	},
 	reactStrictMode: true,
 	publicRuntimeConfig: {
 		// remove private env variables


### PR DESCRIPTION
**NOTE**: This PR should be tested against a running cluster to ensure there are no breaking changes due to the change in `next.config.js` exposing the `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` env var at build time. Because these changes happen at build time, it should not have any effect, but is worth a double check. Unfortunately this needs to be done manually for now while e2e tests are still in development.

To test:
- Have an OpenShift or Kubernetes cluster running & logged into
- Build the container image for this PR
- Deploy TAS to the cluster using said container image, where an environment variable `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` should be set to the Rekor server automatically (whether you deploy by the Helm chart or the operator)
- If Rekor Search UI uses that value rather than the default upstream value of sigstore.dev, then everything is fine 🙆‍♀️ 