### PR TITLE
chore: add pre-push git hooks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run format
+npm run test
+npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"eslint-config-next": "13.0.0",
 				"eslint-config-prettier": "9.1.0",
 				"eslint-plugin-testing-library": "^6.2.0",
+				"husky": "^9.0.11",
 				"jest": "^29.7.0",
 				"jest-environment-jsdom": "^29.7.0",
 				"prettier": "3.2.5",
@@ -6017,6 +6018,21 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/husky": {
+			"version": "9.0.11",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+			"integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+			"dev": true,
+			"bin": {
+				"husky": "bin.mjs"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -15652,6 +15668,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true
+		},
+		"husky": {
+			"version": "9.0.11",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+			"integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
 			"dev": true
 		},
 		"iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"format:fix": "prettier --write .",
 		"lint": "next lint",
 		"generate": "./hack/generate_types.sh",
+		"prepare": "husky",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"test:ci": "jest --ci"
@@ -48,6 +49,7 @@
 		"eslint-config-next": "13.0.0",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-testing-library": "^6.2.0",
+		"husky": "^9.0.11",
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"prettier": "3.2.5",


### PR DESCRIPTION
This PR adds a pre-push git hook using [Husky](https://typicode.github.io/husky/).

On `git push` it will run the following commands:
- `npm run format` to check if changes comply with Prettier config
- `npm run test` to check if changes break tests
- `npm run build` to check if changes break the ability to build the app