### PR TITLE
[SECURESIGN-687] fix(settings): sanitize URL

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
 				"husky": "^9.0.11",
 				"jest": "^29.7.0",
 				"jest-environment-jsdom": "^29.7.0",
-				"lint-staged": "^15.2.2",
 				"prettier": "3.2.5",
 				"storybook": "^8.0.7",
 				"typescript": "4.6.2"
@@ -10059,72 +10058,6 @@
 				"@colors/colors": "1.5.0"
 			}
 		},
-		"node_modules/cli-truncate": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-			"dev": true,
-			"dependencies": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/emoji-regex": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-			"dev": true
-		},
-		"node_modules/cli-truncate/node_modules/string-width": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-			"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -12395,12 +12328,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"dev": true
-		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -13247,18 +13174,6 @@
 			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-			"dev": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-func-name": {
@@ -17147,307 +17062,11 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/lilconfig": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-			"integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
-		},
-		"node_modules/lint-staged": {
-			"version": "15.2.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.2.tgz",
-			"integrity": "sha512-TiTt93OPh1OZOsb5B7k96A/ATl2AjIZo+vnzFZ6oHK5FuTk63ByDtxGQpHm+kFETjEWqgkF95M8FRXKR/LEBcw==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "5.3.0",
-				"commander": "11.1.0",
-				"debug": "4.3.4",
-				"execa": "8.0.1",
-				"lilconfig": "3.0.0",
-				"listr2": "8.0.1",
-				"micromatch": "4.0.5",
-				"pidtree": "0.6.0",
-				"string-argv": "0.3.2",
-				"yaml": "2.3.4"
-			},
-			"bin": {
-				"lint-staged": "bin/lint-staged.js"
-			},
-			"engines": {
-				"node": ">=18.12.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/lint-staged"
-			}
-		},
-		"node_modules/lint-staged/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/lint-staged/node_modules/commander": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/lint-staged/node_modules/execa": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^8.0.1",
-				"human-signals": "^5.0.0",
-				"is-stream": "^3.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^5.1.0",
-				"onetime": "^6.0.0",
-				"signal-exit": "^4.1.0",
-				"strip-final-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/lint-staged/node_modules/get-stream": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-			"dev": true,
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/human-signals": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=16.17.0"
-			}
-		},
-		"node_modules/lint-staged/node_modules/is-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/mimic-fn": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/npm-run-path": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/onetime": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/lint-staged/node_modules/strip-final-newline": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/lint-staged/node_modules/yaml": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-			"integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/listr2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.1.tgz",
-			"integrity": "sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==",
-			"dev": true,
-			"dependencies": {
-				"cli-truncate": "^4.0.0",
-				"colorette": "^2.0.20",
-				"eventemitter3": "^5.0.1",
-				"log-update": "^6.0.0",
-				"rfdc": "^1.3.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/listr2/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/listr2/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/listr2/node_modules/emoji-regex": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-			"dev": true
-		},
-		"node_modules/listr2/node_modules/string-width": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-			"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/listr2/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/listr2/node_modules/wrap-ansi": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
 		},
 		"node_modules/loader-runner": {
 			"version": "4.3.0",
@@ -17581,178 +17200,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/log-update": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
-			"integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
-			"dev": true,
-			"dependencies": {
-				"ansi-escapes": "^6.2.0",
-				"cli-cursor": "^4.0.0",
-				"slice-ansi": "^7.0.0",
-				"strip-ansi": "^7.1.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/ansi-escapes": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/cli-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/emoji-regex": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-			"dev": true
-		},
-		"node_modules/log-update/node_modules/is-fullwidth-code-point": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-			"integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
-			"dev": true,
-			"dependencies": {
-				"get-east-asian-width": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/restore-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-			"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-			"dev": true,
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/slice-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
-			"integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/string-width": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-			"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/wrap-ansi": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/loose-envify": {
@@ -19291,18 +18738,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true,
-			"bin": {
-				"pidtree": "bin/pidtree.js"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -20663,12 +20098,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rfdc": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-			"integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-			"dev": true
-		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -21170,46 +20599,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -21439,15 +20828,6 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
-			}
-		},
-		"node_modules/string-argv": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6.19"
 			}
 		},
 		"node_modules/string-length": {
@@ -30434,50 +29814,6 @@
 				"string-width": "^4.2.0"
 			}
 		},
-		"cli-truncate": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-			"dev": true,
-			"requires": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^7.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "10.3.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-					"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-					"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^10.3.0",
-						"get-east-asian-width": "^1.0.0",
-						"strip-ansi": "^7.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^6.0.1"
-					}
-				}
-			}
-		},
 		"client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -32230,12 +31566,6 @@
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true
 		},
-		"eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"dev": true
-		},
 		"events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -32912,12 +32242,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
-		"get-east-asian-width": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
 			"dev": true
 		},
 		"get-func-name": {
@@ -35743,197 +35067,11 @@
 				"type-check": "~0.4.0"
 			}
 		},
-		"lilconfig": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-			"integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-			"dev": true
-		},
 		"lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
-		},
-		"lint-staged": {
-			"version": "15.2.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.2.tgz",
-			"integrity": "sha512-TiTt93OPh1OZOsb5B7k96A/ATl2AjIZo+vnzFZ6oHK5FuTk63ByDtxGQpHm+kFETjEWqgkF95M8FRXKR/LEBcw==",
-			"dev": true,
-			"requires": {
-				"chalk": "5.3.0",
-				"commander": "11.1.0",
-				"debug": "4.3.4",
-				"execa": "8.0.1",
-				"lilconfig": "3.0.0",
-				"listr2": "8.0.1",
-				"micromatch": "4.0.5",
-				"pidtree": "0.6.0",
-				"string-argv": "0.3.2",
-				"yaml": "2.3.4"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-					"dev": true
-				},
-				"commander": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-					"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-					"dev": true
-				},
-				"execa": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-					"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.3",
-						"get-stream": "^8.0.1",
-						"human-signals": "^5.0.0",
-						"is-stream": "^3.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^5.1.0",
-						"onetime": "^6.0.0",
-						"signal-exit": "^4.1.0",
-						"strip-final-newline": "^3.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-					"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-					"dev": true
-				},
-				"human-signals": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-					"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-					"dev": true
-				},
-				"is-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-					"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-					"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-					"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-					"dev": true,
-					"requires": {
-						"path-key": "^4.0.0"
-					}
-				},
-				"onetime": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-					"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^4.0.0"
-					}
-				},
-				"path-key": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-					"dev": true
-				},
-				"strip-final-newline": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-					"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-					"dev": true
-				},
-				"yaml": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-					"integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-					"dev": true
-				}
-			}
-		},
-		"listr2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.1.tgz",
-			"integrity": "sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==",
-			"dev": true,
-			"requires": {
-				"cli-truncate": "^4.0.0",
-				"colorette": "^2.0.20",
-				"eventemitter3": "^5.0.1",
-				"log-update": "^6.0.0",
-				"rfdc": "^1.3.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-					"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "10.3.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-					"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-					"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^10.3.0",
-						"get-east-asian-width": "^1.0.0",
-						"strip-ansi": "^7.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^6.0.1"
-					}
-				},
-				"wrap-ansi": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-					"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^6.2.1",
-						"string-width": "^7.0.0",
-						"strip-ansi": "^7.1.0"
-					}
-				}
-			}
 		},
 		"loader-runner": {
 			"version": "4.3.0",
@@ -36031,114 +35169,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"log-update": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
-			"integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^6.2.0",
-				"cli-cursor": "^4.0.0",
-				"slice-ansi": "^7.0.0",
-				"strip-ansi": "^7.1.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
-					"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-					"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-					"dev": true
-				},
-				"cli-cursor": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-					"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^4.0.0"
-					}
-				},
-				"emoji-regex": {
-					"version": "10.3.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-					"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-					"integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
-					"dev": true,
-					"requires": {
-						"get-east-asian-width": "^1.0.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-					"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"slice-ansi": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
-					"integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^6.2.1",
-						"is-fullwidth-code-point": "^5.0.0"
-					}
-				},
-				"string-width": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-					"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^10.3.0",
-						"get-east-asian-width": "^1.0.0",
-						"strip-ansi": "^7.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^6.0.1"
-					}
-				},
-				"wrap-ansi": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-					"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^6.2.1",
-						"string-width": "^7.0.0",
-						"strip-ansi": "^7.1.0"
 					}
 				}
 			}
@@ -37286,12 +36316,6 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"devOptional": true
 		},
-		"pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true
-		},
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -38311,12 +37335,6 @@
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
-		"rfdc": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-			"integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-			"dev": true
-		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -38665,30 +37683,6 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
-		"slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-					"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-					"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-					"dev": true
-				}
-			}
-		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -38884,12 +37878,6 @@
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
-		},
-		"string-argv": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-			"dev": true
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -64,16 +64,8 @@
 		"husky": "^9.0.11",
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
-		"lint-staged": "^15.2.2",
 		"prettier": "3.2.5",
 		"storybook": "^8.0.7",
 		"typescript": "4.6.2"
-	},
-	"lint-staged": {
-		"!(*stories).{ts,tsx}": [
-			"prettier --write",
-			"next lint --max-warnings 0 --fix --file ."
-		],
-		"!(*stories).{js,css,md}": "prettier --write"
 	}
 }

--- a/src/__mocks__/atobMock.js
+++ b/src/__mocks__/atobMock.js
@@ -1,9 +1,8 @@
 const atobMock = () => {
 	window.atob = jest.fn().mockImplementation(str => {
-		const decoded = Buffer.from(str, "base64").toString("utf-8");
-		console.log(`Decoding: ${str}, Result: ${decoded}`);
+		// console.log(`Decoding: ${str}, Result: ${Buffer.from(str, "base64").toString("utf-8")}`);
 
-		return decoded;
+		return Buffer.from(str, "base64").toString("utf-8");
 	});
 };
 

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -30,8 +30,12 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 		Variables missing this prefix are only accessible in the Node.js environment.
 		https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 		*/
-		if (baseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
-			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
+		if (baseUrl === undefined) {
+			if (process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
+				setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
+			} else {
+				setBaseUrl("https://rekor.sigstore.dev");
+			}
 		}
 
 		return {

--- a/src/modules/components/SearchForm.tsx
+++ b/src/modules/components/SearchForm.tsx
@@ -12,7 +12,7 @@ import {
 	Popover,
 	TextInput,
 } from "@patternfly/react-core";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect } from "react";
 import { Controller, RegisterOptions, useForm } from "react-hook-form";
 import { Attribute, ATTRIBUTES } from "../api/rekor_api";
 import { ExclamationCircleIcon, HelpIcon } from "@patternfly/react-icons";

--- a/src/modules/utils/utils.test.ts
+++ b/src/modules/utils/utils.test.ts
@@ -1,0 +1,34 @@
+import { isAcceptedProtocol, isValidUrl, validateUrl } from "./validateUrl";
+
+describe("URL Validation Tests", () => {
+	describe("Individual Function Tests", () => {
+		it("isValidUrl: should validate URL structure", () => {
+			expect(isValidUrl("http://validsite.com")).toBe(true);
+			expect(isValidUrl("justastring")).toBe(false);
+			expect(isValidUrl("")).toBe(false);
+			expect(isValidUrl("http://invalidhostname")).toBe(false);
+		});
+
+		it("isAcceptedProtocol: should check for https protocols", () => {
+			expect(isAcceptedProtocol("http://example.com")).toBe(false);
+			expect(isAcceptedProtocol("example.com")).toBe(false);
+			expect(isAcceptedProtocol("www.example.com")).toBe(false);
+			expect(isAcceptedProtocol("ftp://example.com")).toBe(false);
+			expect(isAcceptedProtocol("https://example.com")).toBe(true);
+		});
+	});
+
+	describe("validateUrl: Composite Function Tests", () => {
+		it("should return true for valid URLs with correct protocol", () => {
+			expect(validateUrl("https://example.com")).toBe(true);
+		});
+
+		it("should return false for valid URLs with incorrect protocol", () => {
+			expect(validateUrl("ftp://example.com")).toBe(false);
+		});
+
+		it("should return false for invalid URLs", () => {
+			expect(validateUrl("justastring")).toBe(false);
+		});
+	});
+});

--- a/src/modules/utils/validateUrl.ts
+++ b/src/modules/utils/validateUrl.ts
@@ -1,0 +1,33 @@
+export function validateUrl(url?: string): boolean {
+	if (!url) return false;
+	return isAcceptedProtocol(url) && isValidUrl(url);
+}
+
+/**
+ * Checks if the given URL is using an accepted protocol.
+ * @param url The URL to validate.
+ * @returns True if the URL is valid, false otherwise.
+ */
+export function isAcceptedProtocol(url: string): boolean {
+	try {
+		const parsedUrl = new URL(url);
+		return ["https:"].includes(parsedUrl.protocol);
+	} catch (error) {
+		return false;
+	}
+}
+
+/**
+ * Checks if the given string is a valid URL.
+ * @param url The URL to validate.
+ * @returns True if the URL is valid, false otherwise.
+ */
+export const isValidUrl = (url: string): boolean => {
+	try {
+		const parsedUrl = new URL(url);
+		// check for presence of a dot
+		return parsedUrl.hostname.includes(".");
+	} catch (error) {
+		return false;
+	}
+};


### PR DESCRIPTION
This PR addresses [SECURESIGN-687](https://issues.redhat.com/browse/SECURESIGN-687).

Changes:
- adds a composite validation check to the Rekor endpoint URL input, which is then used in the `Settings` component
- adds check for the accepted protocols (currently only `https`)
- adds check that URL is a valid URL, and additionally that it contains a dot
- adds tests to cover the above scenarios
- adds validation to the `Settings` form
- sets "https://rekor.sigstore.dev"` as the backup now from `context` ahead of time if `process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` does not exist

## Screenshots of Validation

![Screenshot 2024-04-25 at 12 41 45 PM](https://github.com/securesign/rekor-search-ui/assets/3844502/c3115c00-53d6-4a87-a0c4-fb3623e990b5)

![Screenshot 2024-04-25 at 12 41 54 PM](https://github.com/securesign/rekor-search-ui/assets/3844502/a87edefd-83b9-46a7-8af6-553e6c3b2979)
