### PR TITLE
ci(build): switch from getServerSideProps to getInitialProps

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -73,8 +73,6 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-      - name: Extract repository name
-        run: echo "BASE_PATH=/$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_ENV
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} build && touch ./out/.nojekyll
         env:

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -29,8 +29,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4.1.3
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -73,16 +73,18 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Extract repository name
+        run: echo "BASE_PATH=/$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_ENV
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        run: ${{ steps.detect-package-manager.outputs.runner }} build && touch ./out/.nojekyll
         env:
           NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: ${{ secrets.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN }}
       #      - name: Static HTML export with Next.js
       #        run: ${{ steps.detect-package-manager.outputs.runner }} next export
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ./out
+  #      - name: Upload artifact
+  #        uses: actions/upload-pages-artifact@v4
+  #        with:
+  #          path: ./out
 
   # Deployment job
   deploy:
@@ -92,6 +94,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+      #      - name: Deploy to GitHub Pages
+      #        id: deployment
+      #        uses: actions/deploy-pages@v4
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+          folder: out

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # production
 /build
 /.next
+out
 
 # misc
 .DS_Store

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,4 +2,10 @@
 import "@testing-library/jest-dom";
 import { TextEncoder, TextDecoder } from "util";
 
+jest.mock("next/config", () => () => ({
+	publicRuntimeConfig: {
+		NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: "https://rekor.sigstore.dev",
+	},
+}));
+
 Object.assign(global, { TextDecoder, TextEncoder });

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,12 @@ const nextConfig = {
 			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN,
 	},
 	reactStrictMode: true,
+	assetPrefix: "./",
+	images: {
+		loader: "akamai",
+		path: "",
+	},
+	output: "export",
 	publicRuntimeConfig: {
 		// remove private env variables
 		processEnv: Object.fromEntries(

--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from "react";
 import { RekorClient } from "rekor";
+import getConfig from "next/config";
 
 export interface RekorClientContext {
 	client: RekorClient;
@@ -22,6 +23,7 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 	children,
 }) => {
 	const [baseUrl, setBaseUrl] = useState<string>();
+	const { publicRuntimeConfig } = getConfig();
 
 	const context: RekorClientContext = useMemo(() => {
 		/*
@@ -31,8 +33,8 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 		https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 		*/
 		if (baseUrl === undefined) {
-			if (process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
-				setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
+			if (publicRuntimeConfig.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
+				setBaseUrl(publicRuntimeConfig.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
 			} else {
 				setBaseUrl("https://rekor.sigstore.dev");
 			}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,20 @@
 import type { AppProps } from "next/app";
 import "@patternfly/react-core/dist/styles/base.css";
+import { NextPageContext } from "next";
 
 function App({ Component, pageProps }: AppProps) {
 	return <Component {...pageProps} />;
 }
+
+App.getInitialProps = async (_ctx: NextPageContext) => {
+	return {
+		props: {
+			NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: process.env
+				.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+				? process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
+				: null,
+		}, // gets passed to the page component as props
+	};
+};
 
 export default App;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -112,14 +112,3 @@ const PageComponent: NextPage = () => (
 	</RekorClientProvider>
 );
 export default PageComponent;
-
-export async function getServerSideProps() {
-	return {
-		props: {
-			NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: process.env
-				.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
-				? process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
-				: null,
-		}, // gets passed to the page component as props
-	};
-}


### PR DESCRIPTION
This PR attempts to re-enable static building of the Next.js app, which required that we change from `getServerSideProps` to `getInitialProps`, making the endpoint available both on the server and the client.

P.S. Note that this temporarily disables automatic static optimization, which is fine because we should probably upgrade to use AppRouter at some point anyway and the app is still small.

P.S.S. It's unclear whether we need to switch the GitHub action as I've done below, so this will be more of an experiment than anything and may need a follow-up commit. Right now it's the recommended way to deploy Next.js as a static site on GitHub pages.