### PR TITLE
fix(build): override env var with manually-defined localBaseUrl

### DIFF
--- a/src/modules/api/context.tsx
+++ b/src/modules/api/context.tsx
@@ -7,7 +7,6 @@ import {
 	useState,
 } from "react";
 import { RekorClient } from "rekor";
-import getConfig from "next/config";
 
 export interface RekorClientContext {
 	client: RekorClient;
@@ -23,21 +22,10 @@ export const RekorClientProvider: FunctionComponent<PropsWithChildren<{}>> = ({
 	children,
 }) => {
 	const [baseUrl, setBaseUrl] = useState<string>();
-	const { publicRuntimeConfig } = getConfig();
 
 	const context: RekorClientContext = useMemo(() => {
-		/*
-		Using the Next.js framework, the NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN env variable requires
-		a NEXT_PUBLIC_* prefix to make the value of the variable accessible to the browser.
-		Variables missing this prefix are only accessible in the Node.js environment.
-		https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
-		*/
-		if (baseUrl === undefined) {
-			if (publicRuntimeConfig.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
-				setBaseUrl(publicRuntimeConfig.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
-			} else {
-				setBaseUrl("https://rekor.sigstore.dev");
-			}
+		if (baseUrl === undefined && process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN) {
+			setBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
 		}
 
 		return {


### PR DESCRIPTION
This PR fixes an issue with the build and Rekor endpoint. `.env.local` file was not being picked up for pre-defining `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` at runtime, and user-defined endpoints in the UI (via Settings modal) was further not overriding that default value.

Changes:
- Revert react-hook-form changes for sanitization of the endpoint URL, and instead use PatternFly and validation natively as we were before, because it affects how `baseUrl` is used in React Context
- Use `process.env` instead of `getConfig` from next.js, which also seems unreliable
- Incorporate some of Masha (UXD)'s feedback request to only validate on submit

<img width="1301" alt="Screenshot 2024-04-30 at 6 32 15 PM" src="https://github.com/securesign/rekor-search-ui/assets/3844502/0dc054c0-d4f1-450e-b7d5-c0b12c494529">

<img width="1710" alt="Screenshot 2024-04-30 at 6 40 29 PM" src="https://github.com/securesign/rekor-search-ui/assets/3844502/1952a0a9-ad22-4e78-a76c-91284dfd40e5">
