### PR TITLE
fix: use publicRuntimeConfig

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,8 @@ const nextConfig = {
 	},
 	// output: "export",
 	publicRuntimeConfig: {
+		NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN:
+			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN,
 		// remove private env variables
 		processEnv: Object.fromEntries(
 			Object.entries(process.env).filter(([key]) =>

--- a/src/modules/components/Settings.tsx
+++ b/src/modules/components/Settings.tsx
@@ -36,32 +36,30 @@ export function Settings({
 		}
 	}, []);
 
+	const handleClose = useCallback(() => {
+		setLocalBaseUrl(baseUrl);
+		setShowValidation(false);
+		onClose();
+	}, [baseUrl, onClose]);
+
 	const onSave = useCallback(() => {
 		if (!validateUrl(localBaseUrl)) {
-			console.log(!validateUrl(localBaseUrl));
 			setShowValidation(true);
 			return;
 		} else {
+			setBaseUrl(localBaseUrl);
 			setShowValidation(false);
 		}
 
-		if (
-			localBaseUrl === undefined &&
-			process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN
-		) {
-			setLocalBaseUrl(process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN);
-		}
-
-		setBaseUrl(localBaseUrl);
 		onClose();
-	}, [localBaseUrl, setBaseUrl, onClose]);
+	}, [localBaseUrl, onClose, setBaseUrl]);
 
 	return (
 		<Modal
 			variant={ModalVariant.small}
 			title="Settings"
 			isOpen={open}
-			onClose={onClose}
+			onClose={handleClose}
 			actions={[
 				<Button
 					key="confirm"
@@ -73,7 +71,7 @@ export function Settings({
 				<Button
 					key="cancel"
 					variant="link"
-					onClick={onClose}
+					onClick={handleClose}
 				>
 					Cancel
 				</Button>,
@@ -99,7 +97,7 @@ export function Settings({
 					fieldId="rekor-endpoint-override"
 				>
 					<TextInput
-						value={localBaseUrl ?? "https://rekor.sigstore.dev"}
+						value={localBaseUrl ?? baseUrl}
 						type="text"
 						onChange={handleChangeBaseUrl}
 						placeholder={


### PR DESCRIPTION
This PR fixes yet another issue with overriding the Rekor endpoint, where the fallback (upstream API) appeared to be used by default, but the reason was because the `process.env.NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` was not being passed as a runtime config properly.

I've added the business requirements for overriding the Rekor endpoint at the bottom just to confirm I've fully tested everything.

NOTE: This has only been verified manually, there are no e2e tests for this fix yet, PR to follow shortly.

## Context
Tested as follows:

1. Scenario: `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` is defined at runtime:

```
docker build --rm -t quay.io/kahboom/rekor-search-ui:latest -f Dockerfile .

docker run -p 3000:3000 -e NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN='https://www.example.com' quay.io/kahboom/rekor-search-ui:latest
```
- Confirmed that env var specified at runtime is working by checking the network logs and requests are being made to `"https://www.example.com"`
- Confirmed in the Settings UI that `"https://www.example.com"` is the value in the overridden field
- Confirmed that when changing the overridden value in the Settings modal that requests are subsequently made to the new endpoint

2. Scenario: Not defining anything for the `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` should fallback to upstream API `"https://rekor.sigstore.dev"`

- Confirmed that it's working by running it just as above, and requests are being made to the upstream API
- Confirmed in the Settings UI that it matches requests being made
- Confirmed that when changing the overridden value in the Settings modal that requests are updated

### Changes
- Uses Next.js native `publicRuntimeConfig` variable as opposed to doing a manual copy of the `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` value
- Adds a `useEffect` to watch for changes to the `publicRuntimeConfig`, and only use the new value if there is nothing already set manually by the user (i.e. `baseUrl` is `undefined`)
- Fixes a bug where setting an invalid value for the endpoint still stores it locally and (incorrectly) shows it as the endpoint value
- Fixes a bug where the Settings was not properly updating the `baseUrl` value in the context

### Endpoint Requirements

- User-defined Rekor endpoint (for example, via the UI in the Settings modal) takes precedence over a Rekor endpoint defined anywhere else, including an environment variable
- If there is no manually-specified-through-the-UI endpoint, check if it's defined in the `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` environment variable, and use that
- If there's nothing in `NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN` and the user hasn't overridden the endpoint, then use upstream API as the fallback (`"https://rekor.sigstore.dev"`)
