### PR TITLE
fix(SECURESIGN-1422): support handling ArrayBuffer for x509

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Ignore node_modules
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Ignore environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Ignore build outputs
+build
+dist
+
+# Ignore logs
+*.log
+logs
+*.log.*
+*.log.[0-9]*
+
+# Ignore coverage reports
+coverage
+*.lcov
+
+# Ignore TypeScript build files
+*.tsbuildinfo
+
+# Ignore editor directories and files
+.vscode/
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+
+# Ignore Docker-related files
+Dockerfile
+
+# Ignore miscellaneous OS files
+.DS_Store
+Thumbs.db

--- a/src/modules/components/HashedRekord.test.tsx
+++ b/src/modules/components/HashedRekord.test.tsx
@@ -13,6 +13,9 @@ import { HashedRekorV001Schema } from "rekor";
 
 describe("HashedRekordViewer", () => {
 	it("renders the component with a public key", () => {
+		// mock decodex509 to return an empty object
+		decodex509Mock.mockReturnValueOnce({});
+
 		const mockedRekord: HashedRekorV001Schema = {
 			data: {
 				hash: {
@@ -37,8 +40,14 @@ describe("HashedRekordViewer", () => {
 	});
 
 	it("renders the component with a public key certificate", () => {
+		// mock decodex509 to return a mocked certificate
+		decodex509Mock.mockReturnValueOnce({
+			publicKey:
+				"-----BEGIN CERTIFICATE-----Mocked Certificate-----END CERTIFICATE-----",
+			subject: "Mocked Subject",
+		});
+
 		const mockedRekordWithCert = {
-			// simulate a certificate
 			data: {},
 			signature: {
 				publicKey: {
@@ -53,7 +62,7 @@ describe("HashedRekordViewer", () => {
 
 		expect(
 			screen.getByText(
-				/'-----BEGIN CERTIFICATE-----Mocked Certificate-----END CERTIFICATE-----'/,
+				/-----BEGIN CERTIFICATE-----Mocked Certificate-----END CERTIFICATE-----/,
 			),
 		).toBeInTheDocument();
 	});


### PR DESCRIPTION
Fixes a blocking issue where querying in Rekor Search UI causes the app to break. A [previous bump](https://github.com/securesign/rekor-search-ui/pull/125) of the `x509` package added support for textual encoding, but also changed the output to an `ArrayObject` type. This was a missed breaking change, as the package we use (called js-yaml) to convert js objects into YAML, didn't support this format OOTB.

fixes [SECURESIGN-1422](https://issues.redhat.com/browse/SECURESIGN-1422)

Changes:
- add an iterative check (of `X.509` extensions) for existence of `ArrayBuffer` before passing cert output to `js-yaml` for serialization
- chore: add an interface for `DecodedCert` to match the `decodedCert` object
- feat(rekord): handle public keys separately from certs, fixing a broken unit test for `HashedRekordViewer`
- chore: add dockerignore to prevent accidental issues where building a test image locally picks up on overriding the Rekor endpoint (i.e. via a `.env.local` file, for example)

Tested locally on macOS and Fedora, and remotely on a Rosa cluster.