### PR TITLE
chore(deps): sync with upstream

### DIFF
--- a/src/modules/components/Entry.tsx
+++ b/src/modules/components/Entry.tsx
@@ -37,7 +37,11 @@ const DUMP_OPTIONS: jsyaml.DumpOptions = {
 	replacer: (key, value) => {
 		if (Convert.isBase64(value)) {
 			try {
-				return load(window.atob(value));
+				let decodedVal = window.atob(value);
+				if (decodedVal.startsWith("-----BEGIN")) {
+					return decodedVal;
+				}
+				return load(decodedVal);
 			} catch (e) {
 				return value;
 			}

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -63,9 +63,7 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 	"2.5.29.17": {
 		name: "Subject Alternative Name",
 		toJSON(rawExtension: Extension) {
-			return new SubjectAlternativeNameExtension(
-				rawExtension.rawData,
-			).toTextObject();
+			return new SubjectAlternativeNameExtension(rawExtension.rawData).toJSON();
 		},
 	},
 	"2.5.29.19": {

--- a/src/modules/x509/extensions.ts
+++ b/src/modules/x509/extensions.ts
@@ -63,7 +63,9 @@ export const EXTENSIONS_CONFIG: Record<string, ExtensionConfig> = {
 	"2.5.29.17": {
 		name: "Subject Alternative Name",
 		toJSON(rawExtension: Extension) {
-			return new SubjectAlternativeNameExtension(rawExtension.rawData).toJSON();
+			return new SubjectAlternativeNameExtension(
+				rawExtension.rawData,
+			).toTextObject();
 		},
 	},
 	"2.5.29.19": {


### PR DESCRIPTION
Most of the [commits upstream](https://github.com/sigstore/rekor-search-ui/commits/main/) have been related to GitHub Actions workflows that we aren't using and transient dependencies that we have resolved separately. There was only one file changed as a result of the 4 new commits cherry-picked, which fixes loading PEM-encoded certificates as YAML.

Resolves https://issues.redhat.com/browse/SECURESIGN-2086