### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for rekor-search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ EXPOSE 3000
 
 LABEL \
     com.redhat.component="trusted-artifact-signer-rekor-ui" \
-    name="trusted-artifact-signer-rekor-ui" \
+    name="rhtas/rekor-search-ui-rhel9" \
+    cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9" \
     version="0.0.1" \
     summary="User Interface for checking Rekor Entries" \
     description="Provides a user interface for checking Rekor Entries through a Node App" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
