### PR TITLE
chore(deps): bump base image from rhel8/nodejs-20-minimal to rhel9/nodejs-24-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM registry.redhat.io/rhel8/nodejs-20-minimal@sha256:c70bc9908652bf9f95fce435e98be70a6dcf675ff7b6677aba7a08009c368926 as builder
+FROM registry.redhat.io/rhel9/nodejs-24-minimal@sha256:1b19c1fbd559e60db8346bd07b3738f6b8f4add2fcc7ac4816fd9208b712274e as builder
 USER root
 
 COPY package.json package-lock.json ./
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Production Stage
-FROM registry.redhat.io/rhel8/nodejs-20-minimal@sha256:c70bc9908652bf9f95fce435e98be70a6dcf675ff7b6677aba7a08009c368926 as production
+FROM registry.redhat.io/rhel9/nodejs-24-minimal@sha256:1b19c1fbd559e60db8346bd07b3738f6b8f4add2fcc7ac4816fd9208b712274e as production
 USER 1001
 EXPOSE 3000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"typescript": "^4.9.5"
 			},
 			"engines": {
-				"node": "20.x"
+				"node": "24.x"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "rekor-search-ui",
 	"version": "0.1.0",
 	"engines": {
-		"node": "20.x"
+		"node": "24.x"
 	},
 	"scripts": {
 		"dev": "next dev",


### PR DESCRIPTION
## Summary
- Cherry-pick of #299 (merged to `release-1.4` on May 13) to `main`
- Bumps base image from deprecated `rhel8/nodejs-20-minimal` to `rhel9/nodejs-24-minimal`
- Updates node engine constraint from `20.x` to `24.x`

## Why
The `deprecated-image-check` Tekton task flags `rhel8/nodejs-20-minimal` as deprecated (RHEL 8 EOL), causing Enterprise Contract failures on the `tas-components-enterprise-contract` check for any snapshot containing `rekor-search`.

This blocks PRs in other repos (e.g. `securesign/timestamp-authority`, `securesign/rekor`) that share the `tas-components` application snapshot.

## Test plan
- [x] Pre-push hooks pass (prettier, jest, next build)
- [ ] Konflux build succeeds with new base image
- [ ] `deprecated-image-check` task passes
- [ ] EC check passes for `tas-components`