### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/rekor-search-pull-request.yaml
+++ b/.tekton/rekor-search-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rekor-search-push.yaml
+++ b/.tekton/rekor-search-push.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: 1.4.0
+    value: 1.5.0
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)